### PR TITLE
Check coordinates when loading from local storage

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -54,7 +54,12 @@ else {
       setLocalStorage();
     }
     loadInputs();
-    displayMap(inputs.latitude, inputs.longitude);
+    if(inputs.latitude === '' || inputs.longitude === '') {
+      locationToCoordinates(formatLocationString());
+    }
+    else {
+      displayMap(inputs.latitude, inputs.longitude);
+    }
   }
 }
 


### PR DESCRIPTION
When the website is first opened, if there is a previous search, it will automatically be loaded. Before, if just a city name was saved, it would not be converted to coordinates and the map would not render (and nothing else would show up). Now, with this PR, that is fixed